### PR TITLE
Support PAPR URLs for openshift-ansible

### DIFF
--- a/tools/normalize-url.js
+++ b/tools/normalize-url.js
@@ -52,5 +52,11 @@ if (match !== null) {
     result("TODO-travis", "travis-ci-org/" + build, `https://api.travis-ci.org/v3/job/${build}/log.txt`);
 }
 
+match = /^https?:\/\/s3\.amazonaws\.com\/+aos-ci\/+ghprb\/+openshift\/+openshift-ansible\/+([A-Za-z0-9.]*)?\/+index\.html$/.exec(url);
+if (match !== null) {
+    const id = match[1].replace(/\/\/+/g, "/");
+    result("jenkins", id, `https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/${id}/output.log`);
+}
+
 console.error(`${path.basename(process.argv[1])}: unknown location: ${url}`);
 process.exit(1);


### PR DESCRIPTION
This uses jenkins formatter to show PAPR logs

Sample url: https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/588e00f6143f84ef133b7f412d5edeff282a3ff6.2.1531514810524260268/index.html